### PR TITLE
fix: npm installの404エラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.0.4",
-    "@radix-ui/react-button": "^1.0.3",
+    "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",


### PR DESCRIPTION
## 概要
`@radix-ui/react-button`が存在しないためnpm installで404エラーが発生していた問題を修正。

## 変更内容
- `@radix-ui/react-button`を`@radix-ui/react-slot`に修正
- 実際のコードで使用されているパッケージと一致させる

Closes #4

Generated with [Claude Code](https://claude.ai/code)